### PR TITLE
Request-registration

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,7 +1,9 @@
-import { Request, Response } from "express";
 import express from "express";
 import FakeApiRule from "./types/fakeApiRule";
+import { RuleMap, HttpMethod, ContentType } from "./types/fakeApiRule";
 import * as DB from "./db";
+import { createRule, fakeARule } from "./util";
+
 // Initialize express application
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -16,75 +18,10 @@ rules.forEach((rule) => {
 });
 
 rules.forEach((rule) => {
-  const responseHandler = (req: Request, res: Response) => {
-    res.status(rule.statusCode);
-    res.setHeader("Content-Type", rule.contentType);
-    // TODO: convert responseBody to rule.contentType
-    res.send(rule.responseBody);
-  };
-
-  // 2. Define the middleware for matching the incoming Content-Type
-  const requestContentTypeMatcher = (
-    req: Request,
-    res: Response,
-    next: Function
-  ) => {
-    const requestContentType = req.headers["content-type"];
-
-    // Normalize content types for comparison (e.g., remove charset or other parameters)
-    const expectedContentType = rule.contentType
-      .toLowerCase()
-      .split(";")[0]
-      .trim();
-    const actualContentType = requestContentType
-      ? requestContentType.toLowerCase().split(";")[0].trim()
-      : "";
-
-    if (actualContentType === expectedContentType) {
-      next();
-    } else {
-      res
-        .status(415)
-        .send(
-          `Unsupported Media Type. Expected 'Content-Type: ${rule.contentType}'`
-        );
-    }
-  };
-  const method = rule.method.toLowerCase();
-
-  switch (method) {
-    case "get":
-      app.get(rule.path, requestContentTypeMatcher, responseHandler);
-      break;
-    case "post":
-      app.post(rule.path, requestContentTypeMatcher, responseHandler);
-      break;
-    case "put":
-      app.put(rule.path, requestContentTypeMatcher, responseHandler);
-      break;
-    case "delete":
-      app.delete(rule.path, requestContentTypeMatcher, responseHandler);
-      break;
-    case "patch":
-      app.patch(rule.path, requestContentTypeMatcher, responseHandler);
-      break;
-    case "options":
-      app.options(rule.path, requestContentTypeMatcher, responseHandler);
-      break;
-    case "head":
-      app.head(rule.path, requestContentTypeMatcher, responseHandler);
-      break;
-    case "all":
-      app.all(rule.path, requestContentTypeMatcher, responseHandler);
-      break;
-    default:
-      console.warn(
-        `Unsupported HTTP method: '${rule.method}' for path '${rule.path}'. Skipping rule.`
-      );
-  }
+  fakeARule(rule, app);
 });
 
-// Listend to the spevified port
+// Listen to the spevified port
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`);
 });

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -21,6 +21,11 @@ rules.forEach((rule) => {
   fakeARule(rule, app);
 });
 
+/**
+ * When implementing a handler for a request from frontend that adds a new rule
+ * use the addRule utility function instead of adding it manually
+ */
+
 // Listen to the spevified port
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,3 +1,4 @@
+import { Request, Response } from "express";
 import express from "express";
 import FakeApiRule from "./types/fakeApiRule";
 import * as DB from "./db";
@@ -12,6 +13,75 @@ const db = DB.initializeDB();
 const rules = DB.getAllRules(db);
 rules.forEach((rule) => {
   fake_api_rules.set({ path: rule.path, method: rule.method }, rule);
+});
+
+rules.forEach((rule) => {
+  const responseHandler = (req: Request, res: Response) => {
+    res.status(rule.statusCode);
+    res.setHeader("Content-Type", rule.contentType);
+    // TODO: convert responseBody to rule.contentType
+    res.send(rule.responseBody);
+  };
+
+  // 2. Define the middleware for matching the incoming Content-Type
+  const requestContentTypeMatcher = (
+    req: Request,
+    res: Response,
+    next: Function
+  ) => {
+    const requestContentType = req.headers["content-type"];
+
+    // Normalize content types for comparison (e.g., remove charset or other parameters)
+    const expectedContentType = rule.contentType
+      .toLowerCase()
+      .split(";")[0]
+      .trim();
+    const actualContentType = requestContentType
+      ? requestContentType.toLowerCase().split(";")[0].trim()
+      : "";
+
+    if (actualContentType === expectedContentType) {
+      next();
+    } else {
+      res
+        .status(415)
+        .send(
+          `Unsupported Media Type. Expected 'Content-Type: ${rule.contentType}'`
+        );
+    }
+  };
+  const method = rule.method.toLowerCase();
+
+  switch (method) {
+    case "get":
+      app.get(rule.path, requestContentTypeMatcher, responseHandler);
+      break;
+    case "post":
+      app.post(rule.path, requestContentTypeMatcher, responseHandler);
+      break;
+    case "put":
+      app.put(rule.path, requestContentTypeMatcher, responseHandler);
+      break;
+    case "delete":
+      app.delete(rule.path, requestContentTypeMatcher, responseHandler);
+      break;
+    case "patch":
+      app.patch(rule.path, requestContentTypeMatcher, responseHandler);
+      break;
+    case "options":
+      app.options(rule.path, requestContentTypeMatcher, responseHandler);
+      break;
+    case "head":
+      app.head(rule.path, requestContentTypeMatcher, responseHandler);
+      break;
+    case "all":
+      app.all(rule.path, requestContentTypeMatcher, responseHandler);
+      break;
+    default:
+      console.warn(
+        `Unsupported HTTP method: '${rule.method}' for path '${rule.path}'. Skipping rule.`
+      );
+  }
 });
 
 // Listend to the spevified port

--- a/backend/src/types/fakeApiRule.ts
+++ b/backend/src/types/fakeApiRule.ts
@@ -1,16 +1,42 @@
 export interface FakeApiRulePayload {
   id: number;
   path: string;
+  method: HttpMethod;
+  statusCode: number;
+  contentType: ContentType;
+  responseBody: string;
+}
+
+export default interface FakeApiRule {
+  path: string;
   method: string;
   statusCode: number;
   contentType: string;
   responseBody: string;
 }
 
-export default interface FakeApiRuleRequest {
-  path: string;
-  method: string;
-  statusCode: number;
-  contentType: string;
-  responseBody: string;
+export type RuleMap = Map<{ path: string; method: string }, FakeApiRule>;
+
+export enum HttpMethod {
+  GET = "GET",
+  POST = "POST",
+  PUT = "PUT",
+  DELETE = "DELETE",
+  PATCH = "PATCH",
+  HEAD = "HEAD",
+  OPTIONS = "OPTIONS",
+  ALL = "ALL",
+}
+
+export enum ContentType {
+  JSON = "application/json",
+  TEXT = "text/plain",
+  HTML = "text/html",
+  XML = "application/xml",
+  FORM_DATA = "multipart/form-data",
+  URL_ENCODED = "application/x-www-form-urlencoded",
+  YAML = "application/x-yaml",
+  CSV = "text/csv",
+  PDF = "application/pdf",
+  ZIP = "application/zip",
 }

--- a/backend/src/types/fakeApiRule.ts
+++ b/backend/src/types/fakeApiRule.ts
@@ -33,8 +33,4 @@ export enum ContentType {
   TEXT = "text/plain",
   HTML = "text/html",
   XML = "application/xml",
-  FORM_DATA = "multipart/form-data",
-  URL_ENCODED = "application/x-www-form-urlencoded",
-  YAML = "application/x-yaml",
-  CSV = "text/csv",
 }

--- a/backend/src/types/fakeApiRule.ts
+++ b/backend/src/types/fakeApiRule.ts
@@ -9,9 +9,9 @@ export interface FakeApiRulePayload {
 
 export default interface FakeApiRule {
   path: string;
-  method: string;
+  method: HttpMethod;
   statusCode: number;
-  contentType: string;
+  contentType: ContentType;
   responseBody: string;
 }
 
@@ -37,6 +37,4 @@ export enum ContentType {
   URL_ENCODED = "application/x-www-form-urlencoded",
   YAML = "application/x-yaml",
   CSV = "text/csv",
-  PDF = "application/pdf",
-  ZIP = "application/zip",
 }

--- a/backend/src/util.ts
+++ b/backend/src/util.ts
@@ -9,8 +9,7 @@ export function fakeARule(rule: FakeApiRule, app: Express.Express) {
   const responseHandler = (req: Request, res: Response) => {
     res.status(rule.statusCode);
     res.setHeader("Content-Type", rule.contentType);
-    // TODO: convert responseBody to rule.contentType
-    res.send(rule.responseBody);
+    res.send(formatMessage(rule.responseBody, rule.contentType));
   };
 
   const requestContentTypeMatcher = (
@@ -109,4 +108,19 @@ export function createRule(
   DB.addRule(db, rule);
   mapping.set({ path: rule.path, method: rule.method }, rule);
   fakeARule(rule, app);
+}
+
+function formatMessage(message: string, contentType: ContentType) {
+  switch (contentType) {
+    case "application/json":
+      return JSON.stringify({ message });
+    case "text/plain":
+      return message;
+    case "text/html":
+      return `<!DOCTYPE html><html><head><title>Message</title></head><body><p>${message}</p></body></html>`;
+    case "application/xml":
+      return `<?xml version="1.0" encoding="UTF-8"?><message>${message}</message>`;
+    default:
+      return message;
+  }
 }

--- a/backend/src/util.ts
+++ b/backend/src/util.ts
@@ -1,0 +1,112 @@
+import FakeApiRule from "./types/fakeApiRule";
+import { Request, Response } from "express";
+import Express from "express";
+import Database from "better-sqlite3";
+import { RuleMap, HttpMethod, ContentType } from "./types/fakeApiRule";
+import * as DB from "./db";
+
+export function fakeARule(rule: FakeApiRule, app: Express.Express) {
+  const responseHandler = (req: Request, res: Response) => {
+    res.status(rule.statusCode);
+    res.setHeader("Content-Type", rule.contentType);
+    // TODO: convert responseBody to rule.contentType
+    res.send(rule.responseBody);
+  };
+
+  const requestContentTypeMatcher = (
+    req: Request,
+    res: Response,
+    next: Function
+  ) => {
+    const requestContentType = req.headers["content-type"];
+    const expectedContentType = rule.contentType
+      .toLowerCase()
+      .split(";")[0]
+      .trim();
+    const actualContentType = requestContentType
+      ? requestContentType.toLowerCase().split(";")[0].trim()
+      : "";
+
+    if (actualContentType === expectedContentType) {
+      next();
+    } else {
+      res
+        .status(415)
+        .send(
+          `Unsupported Media Type. Expected 'Content-Type: ${rule.contentType}'`
+        );
+    }
+  };
+  const method = rule.method.toLowerCase();
+  switch (method) {
+    case "get":
+      app.get(rule.path, requestContentTypeMatcher, responseHandler);
+      break;
+    case "post":
+      app.post(rule.path, requestContentTypeMatcher, responseHandler);
+      break;
+    case "put":
+      app.put(rule.path, requestContentTypeMatcher, responseHandler);
+      break;
+    case "delete":
+      app.delete(rule.path, requestContentTypeMatcher, responseHandler);
+      break;
+    case "patch":
+      app.patch(rule.path, requestContentTypeMatcher, responseHandler);
+      break;
+    case "options":
+      app.options(rule.path, requestContentTypeMatcher, responseHandler);
+      break;
+    case "head":
+      app.head(rule.path, requestContentTypeMatcher, responseHandler);
+      break;
+    case "all":
+      app.all(rule.path, requestContentTypeMatcher, responseHandler);
+      break;
+    default:
+      console.warn(
+        `Unsupported HTTP method: '${rule.method}' for path '${rule.path}'. Skipping rule.`
+      );
+  }
+}
+
+export function createRule(
+  rule: FakeApiRule,
+  db: Database.Database,
+  mapping: RuleMap,
+  app: Express.Express
+) {
+  if (
+    !rule.path ||
+    !rule.method ||
+    !rule.statusCode ||
+    !rule.contentType ||
+    !rule.responseBody
+  ) {
+    throw new Error("Rule cannot contain an empty field");
+  }
+
+  if (!(rule.method in HttpMethod)) {
+    throw new Error(
+      `Rule method '${
+        rule.method
+      }' must be of type HttpMethod. Supported values are ${Object.values(
+        HttpMethod
+      ).join(", ")}.`
+    );
+  }
+
+  if (!(rule.contentType in ContentType)) {
+    throw new Error(
+      `Rule contentType '${
+        rule.contentType
+      }' must be of type ContentType. Supported values are ${Object.values(
+        ContentType
+      ).join(", ")}.`
+    );
+  }
+
+  DB.addRule(db, rule);
+  mapping.set({ path: rule.path, method: rule.method }, rule);
+  fakeARule(rule, app);
+}

--- a/backend/test/databaseTests.ts
+++ b/backend/test/databaseTests.ts
@@ -2,7 +2,11 @@ import assert from "assert";
 import Database from "better-sqlite3";
 import "mocha";
 import FakeApiRule from "../src/types/fakeApiRule";
-import { FakeApiRulePayload } from "../src/types/fakeApiRule";
+import {
+  FakeApiRulePayload,
+  HttpMethod,
+  ContentType,
+} from "../src/types/fakeApiRule";
 import { initializeDB, getAllRules, addRule } from "../src/db";
 
 /**
@@ -89,16 +93,16 @@ describe("getAllRules", () => {
     const db = initializeDB();
     const rule1: FakeApiRule = {
       path: "/api/rule1",
-      method: "GET",
+      method: HttpMethod.GET,
       statusCode: 200,
-      contentType: "application/json",
+      contentType: ContentType.JSON,
       responseBody: "body",
     };
     const rule2: FakeApiRule = {
       path: "/api/rule2",
-      method: "GET",
+      method: HttpMethod.GET,
       statusCode: 200,
-      contentType: "application/json",
+      contentType: ContentType.JSON,
       responseBody: "body",
     };
     db.prepare(
@@ -183,9 +187,9 @@ describe("addRule", () => {
     const db = initializeDB();
     const rule: FakeApiRule = {
       path: "/api/rule1",
-      method: "GET",
+      method: HttpMethod.GET,
       statusCode: 200,
-      contentType: "application/json",
+      contentType: ContentType.JSON,
       responseBody: "body",
     };
     addRule(db, rule);


### PR DESCRIPTION
Server.ts will now automatically set up all known fake apis upon startup. This will be useful if we ever try to make the database persistent. For now it basically polls an empty database. 
Servet.ts now uses utility  functiions to launch existing rules as well as add new ones. 
Newly added api rules will be launched automatically. 